### PR TITLE
add column visibility toggle for Size, Created, Modified

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,92 @@
   ],
   "main": "./extension.js",
   "contributes": {
+    "configuration": {
+      "title": "Explorer+",
+      "properties": {
+        "explorerPlus.showSize": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show file/folder size column"
+        },
+        "explorerPlus.showDateCreated": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show date created column"
+        },
+        "explorerPlus.showDateModified": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show date modified column"
+        }
+      }
+    },
+"commands": [
+      {
+        "command": "explorerPlus.hideSize",
+        "title": "✓ Size",
+        "category": "Explorer+"
+      },
+      {
+        "command": "explorerPlus.showSize",
+        "title": "Size",
+        "category": "Explorer+"
+      },
+      {
+        "command": "explorerPlus.hideDateCreated",
+        "title": "✓ Created",
+        "category": "Explorer+"
+      },
+      {
+        "command": "explorerPlus.showDateCreated",
+        "title": "Created",
+        "category": "Explorer+"
+      },
+      {
+        "command": "explorerPlus.hideDateModified",
+        "title": "✓ Modified",
+        "category": "Explorer+"
+      },
+      {
+        "command": "explorerPlus.showDateModified",
+        "title": "Modified",
+        "category": "Explorer+"
+      }
+    ],
+    "menus": {
+      "view/title": [
+        {
+          "command": "explorerPlus.hideSize",
+          "when": "view == fileExplorerView && explorerPlus.showSize",
+          "group": "1_settings@1"
+        },
+        {
+          "command": "explorerPlus.showSize",
+          "when": "view == fileExplorerView && !explorerPlus.showSize",
+          "group": "1_settings@1"
+        },
+        {
+          "command": "explorerPlus.hideDateCreated",
+          "when": "view == fileExplorerView && explorerPlus.showDateCreated",
+          "group": "1_settings@2"
+        },
+        {
+          "command": "explorerPlus.showDateCreated",
+          "when": "view == fileExplorerView && !explorerPlus.showDateCreated",
+          "group": "1_settings@2"
+        },
+        {
+          "command": "explorerPlus.hideDateModified",
+          "when": "view == fileExplorerView && explorerPlus.showDateModified",
+          "group": "1_settings@3"
+        },
+        {
+          "command": "explorerPlus.showDateModified",
+          "when": "view == fileExplorerView && !explorerPlus.showDateModified",
+          "group": "1_settings@3"
+        }
+      ]
+    },
     "viewsContainers": {
       "activitybar": [
         {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,18 @@
           "type": "boolean",
           "default": true,
           "description": "Show date modified column"
+        },
+        "explorerPlus.dateFormat": {
+          "type": "string",
+          "default": "full",
+          "enum": ["full", "compact", "relative"],
+          "enumDescriptions": [
+            "Full date and time (system locale, e.g. 5/1/2026, 3:14:00 PM)",
+            "Fixed format (e.g. 5/1/26, 15:14)",
+            "Relative (<1yr) / Date (≥1yr) (e.g. 3h ago / Nov 18, 2021)"
+          ],
+          "markdownDescription": "Date/time display format for file dates\n\n- **Full**: system locale date + time (e.g. `5/1/2026, 3:14:00 PM`)\n- **Compact**: fixed format (e.g. `5/1/26, 15:14`)\n- **Relative**: relative time (<1yr) / date (≥1yr) (e.g. `3h ago` / `Nov 18, 2021`)",
+          "order": 10
         }
       }
     },
@@ -66,6 +78,42 @@
         "command": "explorerPlus.showDateModified",
         "title": "Modified",
         "category": "Explorer+"
+      },
+      {
+        "command": "explorerPlus.dateFormatFullActive",
+        "title": "✓ Full",
+        "category": "Explorer+"
+      },
+      {
+        "command": "explorerPlus.dateFormatFull",
+        "title": "Full",
+        "category": "Explorer+"
+      },
+      {
+        "command": "explorerPlus.dateFormatCompactActive",
+        "title": "✓ Compact",
+        "category": "Explorer+"
+      },
+      {
+        "command": "explorerPlus.dateFormatCompact",
+        "title": "Compact",
+        "category": "Explorer+"
+      },
+      {
+        "command": "explorerPlus.dateFormatRelativeActive",
+        "title": "✓ Relative",
+        "category": "Explorer+"
+      },
+      {
+        "command": "explorerPlus.dateFormatRelative",
+        "title": "Relative",
+        "category": "Explorer+"
+      }
+    ],
+    "submenus": [
+      {
+        "id": "explorerPlus.dateFormatSubmenu",
+        "label": "Date Format"
       }
     ],
     "menus": {
@@ -99,6 +147,43 @@
           "command": "explorerPlus.showDateModified",
           "when": "view == fileExplorerView && !explorerPlus.showDateModified",
           "group": "1_settings@3"
+        },
+        {
+          "submenu": "explorerPlus.dateFormatSubmenu",
+          "when": "view == fileExplorerView",
+          "group": "2_dateFormat@1"
+        }
+      ],
+      "explorerPlus.dateFormatSubmenu": [
+        {
+          "command": "explorerPlus.dateFormatFullActive",
+          "when": "explorerPlus.dateFormat == full",
+          "group": "dateFormat@1"
+        },
+        {
+          "command": "explorerPlus.dateFormatFull",
+          "when": "explorerPlus.dateFormat != full",
+          "group": "dateFormat@1"
+        },
+        {
+          "command": "explorerPlus.dateFormatCompactActive",
+          "when": "explorerPlus.dateFormat == compact",
+          "group": "dateFormat@2"
+        },
+        {
+          "command": "explorerPlus.dateFormatCompact",
+          "when": "explorerPlus.dateFormat != compact",
+          "group": "dateFormat@2"
+        },
+        {
+          "command": "explorerPlus.dateFormatRelativeActive",
+          "when": "explorerPlus.dateFormat == relative",
+          "group": "dateFormat@3"
+        },
+        {
+          "command": "explorerPlus.dateFormatRelative",
+          "when": "explorerPlus.dateFormat != relative",
+          "group": "dateFormat@3"
         }
       ]
     },

--- a/src/FileExplorerView.js
+++ b/src/FileExplorerView.js
@@ -1,6 +1,16 @@
 const vscode = require('vscode');
 const path = require('path');
-const { getFolderSizeSync, formatSize, formatDate } = require('./utils/fileUtils'); // Path updated
+const { getFolderSizeSync, formatSize, formatDate } = require('./utils/fileUtils');
+
+// Get column visibility settings
+function getColumnSettings() {
+    const config = vscode.workspace.getConfiguration('explorerPlus');
+    return {
+        showSize: config.get('showSize', true),
+        showDateCreated: config.get('showDateCreated', true),
+        showDateModified: config.get('showDateModified', true)
+    };
+}
 
 class FileExplorerViewProvider {
     /**
@@ -18,6 +28,33 @@ class FileExplorerViewProvider {
         if (workspaceFolders && workspaceFolders.length > 0) {
             this.root = workspaceFolders[0].uri.fsPath;
         }
+
+        // Initialize context keys for view/title commands
+        this._updateContextKeys();
+    }
+
+    /**
+     * Update VS Code context keys based on current settings.
+     * @private
+     */
+    _updateContextKeys() {
+        const config = vscode.workspace.getConfiguration('explorerPlus');
+        vscode.commands.executeCommand('setContext', 'explorerPlus.showSize', config.get('showSize', true));
+        vscode.commands.executeCommand('setContext', 'explorerPlus.showDateCreated', config.get('showDateCreated', true));
+        vscode.commands.executeCommand('setContext', 'explorerPlus.showDateModified', config.get('showDateModified', true));
+    }
+
+    /**
+     * Set a column's visibility.
+     * @param {string} key The configuration key (e.g. 'showSize').
+     * @param {boolean} visible Whether the column should be visible.
+     * @private
+     */
+    _setColumnVisibility(key, visible) {
+        const config = vscode.workspace.getConfiguration('explorerPlus');
+        config.update(key, visible, vscode.ConfigurationTarget.Global);
+        this._updateContextKeys();
+        this._render();
     }
 
     /**
@@ -36,6 +73,26 @@ class FileExplorerViewProvider {
             ]
         };
         this._render(); // Initial render of the webview
+
+        // Register toggle commands
+        this.context.subscriptions.push(
+            vscode.commands.registerCommand('explorerPlus.hideSize', () => this._setColumnVisibility('showSize', false)),
+            vscode.commands.registerCommand('explorerPlus.showSize', () => this._setColumnVisibility('showSize', true)),
+            vscode.commands.registerCommand('explorerPlus.hideDateCreated', () => this._setColumnVisibility('showDateCreated', false)),
+            vscode.commands.registerCommand('explorerPlus.showDateCreated', () => this._setColumnVisibility('showDateCreated', true)),
+            vscode.commands.registerCommand('explorerPlus.hideDateModified', () => this._setColumnVisibility('showDateModified', false)),
+            vscode.commands.registerCommand('explorerPlus.showDateModified', () => this._setColumnVisibility('showDateModified', true))
+        );
+
+        // Listen for configuration changes
+        this.context.subscriptions.push(
+            vscode.workspace.onDidChangeConfiguration(e => {
+                if (e.affectsConfiguration('explorerPlus')) {
+                    this._updateContextKeys();
+                    this._render();
+                }
+            })
+        );
 
         // Handle messages received from the webview
         webviewView.webview.onDidReceiveMessage(async msg => {
@@ -107,6 +164,9 @@ class FileExplorerViewProvider {
             return;
         }
 
+        // Get column visibility settings
+        const columns = getColumnSettings();
+
         const rootPath = this.root || workspaceFolders[0].uri.fsPath;
         let entries = [];
         try {
@@ -172,15 +232,15 @@ class FileExplorerViewProvider {
         });
 
         // Generate HTML for table rows
-        const rows = filtered.map(e => `
+        const rowsHtml = filtered.map(e => `
             <tr data-path="${e.path}" class="row ${e.isDir ? 'folder-row' : 'file-row'}" style="cursor:pointer;">
                 <td style="width:28px;text-align:center;">
                     <span class="mdi ${e.isDir ? 'mdi-folder' : 'mdi-file-outline'}"></span>
                 </td>
                 <td>${e.name}</td>
-                <td style="text-align:right;">${e.size ? formatSize(e.size) : '-'}</td>
-                <td>${e.ctime ? formatDate(e.ctime) : ''}</td>
-                <td>${e.mtime ? formatDate(e.mtime) : ''}</td>
+                ${columns.showSize ? `<td style="text-align:right;">${e.size ? formatSize(e.size) : '-'}</td>` : ''}
+                ${columns.showDateCreated ? `<td>${e.ctime ? formatDate(e.ctime) : ''}</td>` : ''}
+                ${columns.showDateModified ? `<td>${e.mtime ? formatDate(e.mtime) : ''}</td>` : ''}
             </tr>
         `).join('');
 
@@ -189,21 +249,28 @@ class FileExplorerViewProvider {
         // Check if current path is different from workspace root and not a filesystem root itself
         const showUp = this.root && this.root !== workspaceRoot && path.dirname(this.root) !== this.root;
 
-        this.webviewView.webview.html = this._getWebviewContent(rootPath, showUp, rows);
+        this.webviewView.webview.html = this._getWebviewContent(rootPath, showUp, rowsHtml, columns);
     }
 
     /**
      * Generates the full HTML content for the webview.
      * @param {string} rootPath The current directory path being displayed.
      * @param {boolean} showUp Whether to show the "Up" button.
-     * @param {string} rows The HTML string for the table rows.
+     * @param {string} rowsHtml The HTML string for the table rows.
+     * @param {object} columns Column visibility settings.
      * @returns {string} The complete HTML content.
      * @private
      */
-    _getWebviewContent(rootPath, showUp, rows) {
+    _getWebviewContent(rootPath, showUp, rowsHtml, columns) {
         // Get URIs for webview resources
         const scriptUri = this.webviewView.webview.asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, 'src', 'webview', 'webview.js'));
         const styleUri = this.webviewView.webview.asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, 'src', 'webview', 'webview.css'));
+
+        // Count visible columns for colspan
+        let colCount = 2; // icon + name
+        if (columns.showSize) colCount++;
+        if (columns.showDateCreated) colCount++;
+        if (columns.showDateModified) colCount++;
 
         return `
             <!DOCTYPE html>
@@ -230,13 +297,13 @@ class FileExplorerViewProvider {
                             <tr>
                                 <th></th>
                                 <th id="sort-name">Name ${this.sortBy === 'name' ? (this.sortDir === 1 ? '▲' : '▼') : ''}</th>
-                                <th style="text-align:right;" id="sort-size">Size ${this.sortBy === 'size' ? (this.sortDir === 1 ? '▲' : '▼') : ''}</th>
-                                <th id="sort-ctime">Created ${this.sortBy === 'ctime' ? (this.sortDir === 1 ? '▲' : '▼') : ''}</th>
-                                <th id="sort-mtime">Modified ${this.sortBy === 'mtime' ? (this.sortDir === 1 ? '▲' : '▼') : ''}</th>
+                                ${columns.showSize ? `<th style="text-align:right;" id="sort-size">Size ${this.sortBy === 'size' ? (this.sortDir === 1 ? '▲' : '▼') : ''}</th>` : ''}
+                                ${columns.showDateCreated ? `<th id="sort-ctime">Created ${this.sortBy === 'ctime' ? (this.sortDir === 1 ? '▲' : '▼') : ''}</th>` : ''}
+                                ${columns.showDateModified ? `<th id="sort-mtime">Modified ${this.sortBy === 'mtime' ? (this.sortDir === 1 ? '▲' : '▼') : ''}</th>` : ''}
                             </tr>
                         </thead>
                         <tbody>
-                            ${rows || `<tr><td colspan="5" style="color:var(--vscode-descriptionForeground);text-align:center;">No files/folders</td></tr>`}
+                            ${rowsHtml || `<tr><td colspan="${colCount}" style="color:var(--vscode-descriptionForeground);text-align:center;">No files/folders</td></tr>`}
                         </tbody>
                     </table>
                 </div>

--- a/src/FileExplorerView.js
+++ b/src/FileExplorerView.js
@@ -159,6 +159,15 @@ class FileExplorerViewProvider {
                         vscode.window.showErrorMessage(`Could not open file: ${error.message}`);
                     }
                     break;
+                case 'openFileTab':
+                    // Open the file in a new tab in the current editor group (middle-click behavior)
+                    try {
+                        const document = await vscode.workspace.openTextDocument(msg.path);
+                        await vscode.window.showTextDocument(document, { preview: false });
+                    } catch (error) {
+                        vscode.window.showErrorMessage(`Could not open file: ${error.message}`);
+                    }
+                    break;
                 case 'goUp':
                     // Navigate up to the parent directory
                     if (this.root) {

--- a/src/FileExplorerView.js
+++ b/src/FileExplorerView.js
@@ -322,8 +322,30 @@ class FileExplorerViewProvider {
                 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@mdi/font@7.4.47/css/materialdesignicons.min.css">
                 <link rel="stylesheet" href="${styleUri}">
                 <style>
-                    /* Basic styling for VS Code theme integration */
-
+                    body { overflow-x: hidden; }
+                    table { table-layout: fixed; width: 100%; border-collapse: collapse; }
+                    th { overflow: visible; }
+                    td { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+                    th.resizable { position: relative; }
+                    .resize-handle {
+                        position: absolute;
+                        right: 0;
+                        top: 0;
+                        bottom: 0;
+                        width: 1px;
+                        background: var(--vscode-panel-border, #888);
+                        cursor: col-resize;
+                        z-index: 1;
+                    }
+                    .resize-handle:hover,
+                    .resize-handle.active {
+                        width: 4px;
+                        margin-left: -1.5px;
+                        background: var(--vscode-sash-hoverBorder, #007fd4);
+                    }
+                    body.resizing { cursor: col-resize !important; user-select: none; }
+                    body.resizing table { pointer-events: none; }
+                    th.resizable:hover { background-color: var(--vscode-list-hoverBackground); }
                 </style>
             </head>
             <body>
@@ -335,11 +357,11 @@ class FileExplorerViewProvider {
                     <table>
                         <thead>
                             <tr>
-                                <th></th>
-                                <th id="sort-name">Name ${this.sortBy === 'name' ? (this.sortDir === 1 ? '▲' : '▼') : ''}</th>
-                                ${columns.showSize ? `<th style="text-align:right;" id="sort-size">Size ${this.sortBy === 'size' ? (this.sortDir === 1 ? '▲' : '▼') : ''}</th>` : ''}
-                                ${columns.showDateCreated ? `<th id="sort-ctime">Created ${this.sortBy === 'ctime' ? (this.sortDir === 1 ? '▲' : '▼') : ''}</th>` : ''}
-                                ${columns.showDateModified ? `<th id="sort-mtime">Modified ${this.sortBy === 'mtime' ? (this.sortDir === 1 ? '▲' : '▼') : ''}</th>` : ''}
+                                <th style="width:28px;"></th>
+                                <th class="resizable" data-column="name" id="sort-name">Name ${this.sortBy === 'name' ? (this.sortDir === 1 ? '▲' : '▼') : ''}<div class="resize-handle"></div></th>
+                                ${columns.showSize ? `<th class="resizable" data-column="size" style="text-align:right;" id="sort-size">Size ${this.sortBy === 'size' ? (this.sortDir === 1 ? '▲' : '▼') : ''}<div class="resize-handle"></div></th>` : ''}
+                                ${columns.showDateCreated ? `<th class="resizable" data-column="ctime" id="sort-ctime">Created ${this.sortBy === 'ctime' ? (this.sortDir === 1 ? '▲' : '▼') : ''}<div class="resize-handle"></div></th>` : ''}
+                                ${columns.showDateModified ? `<th class="resizable" data-column="mtime" id="sort-mtime">Modified ${this.sortBy === 'mtime' ? (this.sortDir === 1 ? '▲' : '▼') : ''}<div class="resize-handle"></div></th>` : ''}
                             </tr>
                         </thead>
                         <tbody>

--- a/src/FileExplorerView.js
+++ b/src/FileExplorerView.js
@@ -1,6 +1,6 @@
 const vscode = require('vscode');
 const path = require('path');
-const { getFolderSizeSync, formatSize, formatDate } = require('./utils/fileUtils');
+const { getFolderSizeSync, formatSize, formatDate, formatDateCompact, formatDateRelative } = require('./utils/fileUtils');
 
 // Get column visibility settings
 function getColumnSettings() {
@@ -42,6 +42,7 @@ class FileExplorerViewProvider {
         vscode.commands.executeCommand('setContext', 'explorerPlus.showSize', config.get('showSize', true));
         vscode.commands.executeCommand('setContext', 'explorerPlus.showDateCreated', config.get('showDateCreated', true));
         vscode.commands.executeCommand('setContext', 'explorerPlus.showDateModified', config.get('showDateModified', true));
+        vscode.commands.executeCommand('setContext', 'explorerPlus.dateFormat', config.get('dateFormat', 'full'));
     }
 
     /**
@@ -53,6 +54,32 @@ class FileExplorerViewProvider {
     _setColumnVisibility(key, visible) {
         const config = vscode.workspace.getConfiguration('explorerPlus');
         config.update(key, visible, vscode.ConfigurationTarget.Global);
+        this._updateContextKeys();
+        this._render();
+    }
+
+    /**
+     * Cycle the date format: full → compact → relative → full.
+     * @private
+     */
+    _cycleDateFormat() {
+        const config = vscode.workspace.getConfiguration('explorerPlus');
+        const order = ['full', 'compact', 'relative'];
+        const current = config.get('dateFormat', 'full');
+        const nextIndex = (order.indexOf(current) + 1) % order.length;
+        config.update('dateFormat', order[nextIndex], vscode.ConfigurationTarget.Global);
+        this._updateContextKeys();
+        this._render();
+    }
+
+    /**
+     * Set a specific date format.
+     * @param {string} format The format to set ('full', 'compact', or 'relative').
+     * @private
+     */
+    _setDateFormat(format) {
+        const config = vscode.workspace.getConfiguration('explorerPlus');
+        config.update('dateFormat', format, vscode.ConfigurationTarget.Global);
         this._updateContextKeys();
         this._render();
     }
@@ -81,7 +108,13 @@ class FileExplorerViewProvider {
             vscode.commands.registerCommand('explorerPlus.hideDateCreated', () => this._setColumnVisibility('showDateCreated', false)),
             vscode.commands.registerCommand('explorerPlus.showDateCreated', () => this._setColumnVisibility('showDateCreated', true)),
             vscode.commands.registerCommand('explorerPlus.hideDateModified', () => this._setColumnVisibility('showDateModified', false)),
-            vscode.commands.registerCommand('explorerPlus.showDateModified', () => this._setColumnVisibility('showDateModified', true))
+            vscode.commands.registerCommand('explorerPlus.showDateModified', () => this._setColumnVisibility('showDateModified', true)),
+            vscode.commands.registerCommand('explorerPlus.dateFormatFullActive', () => {}),
+            vscode.commands.registerCommand('explorerPlus.dateFormatFull', () => this._setDateFormat('full')),
+            vscode.commands.registerCommand('explorerPlus.dateFormatCompactActive', () => {}),
+            vscode.commands.registerCommand('explorerPlus.dateFormatCompact', () => this._setDateFormat('compact')),
+            vscode.commands.registerCommand('explorerPlus.dateFormatRelativeActive', () => {}),
+            vscode.commands.registerCommand('explorerPlus.dateFormatRelative', () => this._setDateFormat('relative'))
         );
 
         // Listen for configuration changes
@@ -167,6 +200,13 @@ class FileExplorerViewProvider {
         // Get column visibility settings
         const columns = getColumnSettings();
 
+        // Get date format setting
+        const config = vscode.workspace.getConfiguration('explorerPlus');
+        const dateFormat = config.get('dateFormat', 'full');
+        const dateFormatter = dateFormat === 'compact' ? formatDateCompact
+                           : dateFormat === 'relative' ? formatDateRelative
+                           : formatDate;
+
         const rootPath = this.root || workspaceFolders[0].uri.fsPath;
         let entries = [];
         try {
@@ -239,8 +279,8 @@ class FileExplorerViewProvider {
                 </td>
                 <td>${e.name}</td>
                 ${columns.showSize ? `<td style="text-align:right;">${e.size ? formatSize(e.size) : '-'}</td>` : ''}
-                ${columns.showDateCreated ? `<td>${e.ctime ? formatDate(e.ctime) : ''}</td>` : ''}
-                ${columns.showDateModified ? `<td>${e.mtime ? formatDate(e.mtime) : ''}</td>` : ''}
+                ${columns.showDateCreated ? `<td>${e.ctime ? dateFormatter(e.ctime) : ''}</td>` : ''}
+                ${columns.showDateModified ? `<td>${e.mtime ? dateFormatter(e.mtime) : ''}</td>` : ''}
             </tr>
         `).join('');
 

--- a/src/utils/fileUtils.js
+++ b/src/utils/fileUtils.js
@@ -49,7 +49,7 @@ function formatSize(size) {
 }
 
 /**
- * Formats a timestamp into a localized date and time string.
+ * Formats a timestamp into a localized date and time string (full format).
  * @param {number} ts The timestamp in milliseconds.
  * @returns {string} Formatted date string.
  */
@@ -59,8 +59,69 @@ function formatDate(ts) {
     return d.toLocaleString();
 }
 
+/**
+ * Fixed compact date formatter.
+ * Always outputs M/D/YY, HH:mm regardless of elapsed time.
+ * @param {number} ts The timestamp in milliseconds.
+ * @returns {string} Formatted date string.
+ */
+function formatDateCompact(ts) {
+    if (typeof ts !== 'number' || isNaN(ts) || ts === 0) return '';
+    const d = new Date(ts);
+    const M = d.getMonth() + 1;
+    const D = d.getDate();
+    const Y = String(d.getFullYear()).slice(-2);
+    const h = String(d.getHours()).padStart(2, '0');
+    const m = String(d.getMinutes()).padStart(2, '0');
+    return `${M}/${D}/${Y}, ${h}:${m}`;
+}
+
+/**
+ * Relative time formatter with date fallback for old dates.
+ * < 1 year → relative (e.g. "3 hours ago" / "3 小時前")
+ * ≥ 1 year → date format (e.g. "Nov 18, 2021" / "2021年11月18日")
+ * @param {number} ts The timestamp in milliseconds.
+ * @returns {string} Relative time string.
+ */
+function formatDateRelative(ts) {
+    if (typeof ts !== 'number' || isNaN(ts) || ts === 0) return '';
+
+    const diff = Date.now() - ts;
+    if (diff < 0) return formatDate(ts);
+
+    const seconds = Math.floor(diff / 1000);
+    const minutes = Math.floor(seconds / 60);
+    const hours = Math.floor(minutes / 60);
+    const days = Math.floor(hours / 24);
+
+    // ≥ 1 year → fall back to date format
+    if (days >= 365) {
+        const d = new Date(ts);
+        return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+    }
+
+    // < 1 year → relative time
+    const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
+
+    if (seconds < 60) {
+        return 'just now';
+    } else if (minutes < 60) {
+        return rtf.format(-minutes, 'minute');
+    } else if (hours < 24) {
+        return rtf.format(-hours, 'hour');
+    } else if (days < 7) {
+        return rtf.format(-days, 'day');
+    } else if (days < 30) {
+        return rtf.format(-Math.floor(days / 7), 'week');
+    } else {
+        return rtf.format(-Math.floor(days / 30), 'month');
+    }
+}
+
 module.exports = {
     getFolderSizeSync,
     formatSize,
-    formatDate
+    formatDate,
+    formatDateCompact,
+    formatDateRelative
 };

--- a/src/webview/webview.js
+++ b/src/webview/webview.js
@@ -63,4 +63,101 @@
             }
         });
     });
+
+    // Initialize column resize handles
+    (function initColumnResize() {
+        // Apply saved column widths immediately to prevent layout shift
+        try {
+            var saved = JSON.parse(localStorage.getItem('explorer-plus-column-widths') || '{}');
+            var table = document.querySelector('table');
+            var totalSaved = 0;
+            var visibleCols = document.querySelectorAll('th[data-column]');
+            
+            Object.keys(saved).forEach(function(col) { totalSaved += saved[col]; });
+            
+            // Only apply if saved widths fit within current viewport (with 10px buffer)
+            if (totalSaved > 0 && totalSaved <= table.offsetWidth + 10) {
+                visibleCols.forEach(function(th) {
+                    var col = th.dataset.column;
+                    if (saved[col]) th.style.width = saved[col] + 'px';
+                });
+            }
+        } catch(e) {}
+
+        var isResizing = false;
+        var startTh = null;
+        var nextTh = null;
+        var startX = 0;
+        var startWidth = 0;
+        var nextStartWidth = 0;
+
+        function onMouseMove(e) {
+            if (!isResizing) return;
+            var diff = e.clientX - startX;
+            
+            // If resizing the last column, prevent expanding to the right
+            if (!nextTh && diff > 0) return;
+
+            var newWidth = Math.max(30, startWidth + diff);
+            var actualDiff = newWidth - startWidth;
+            
+            if (nextTh) {
+                var newNextWidth = Math.max(30, nextStartWidth - actualDiff);
+                var actualNextDiff = nextStartWidth - newNextWidth;
+                
+                if (actualNextDiff < actualDiff) {
+                    newWidth = startWidth + actualNextDiff;
+                }
+                nextTh.style.width = newNextWidth + 'px';
+            }
+            startTh.style.width = newWidth + 'px';
+        }
+
+        function onMouseUp() {
+            if (!isResizing) return;
+            isResizing = false;
+            var activeHandle = document.querySelector('.resize-handle.active');
+            if (activeHandle) activeHandle.classList.remove('active');
+            document.body.classList.remove('resizing');
+            document.removeEventListener('mousemove', onMouseMove);
+            document.removeEventListener('mouseup', onMouseUp);
+
+            // Save all column widths to localStorage
+            var widths = {};
+            document.querySelectorAll('th[data-column]').forEach(function(th) {
+                widths[th.dataset.column] = th.offsetWidth;
+            });
+            try { localStorage.setItem('explorer-plus-column-widths', JSON.stringify(widths)); } catch(e) {}
+        }
+
+        // Identify the last resizable column to disable its handle
+        var allCols = document.querySelectorAll('th[data-column]');
+        var lastCol = allCols.length > 0 ? allCols[allCols.length - 1] : null;
+
+        document.querySelectorAll('.resize-handle').forEach(function(handle) {
+            var th = handle.parentElement;
+            
+            // Disable resizing for the last column (hide handle and skip listener)
+            if (th === lastCol) {
+                handle.style.display = 'none';
+                return;
+            }
+
+            handle.addEventListener('mousedown', function(e) {
+                e.preventDefault();
+                e.stopPropagation();
+                isResizing = true;
+                startTh = this.parentElement;
+                nextTh = startTh.nextElementSibling;
+                startX = e.clientX;
+                startWidth = startTh.offsetWidth;
+                nextStartWidth = nextTh ? nextTh.offsetWidth : 0;
+                this.classList.add('active');
+                document.body.classList.add('resizing');
+
+                document.addEventListener('mousemove', onMouseMove);
+                document.addEventListener('mouseup', onMouseUp);
+            });
+        });
+    })();
 }());

--- a/src/webview/webview.js
+++ b/src/webview/webview.js
@@ -44,22 +44,37 @@
 
     // Event listener for clicking on file/folder rows
     document.querySelectorAll('tr.row').forEach(row => {
-        row.addEventListener('click', () => {
+        // Use mousedown to detect which mouse button was pressed
+        row.addEventListener('mousedown', (e) => {
             const path = row.dataset.path; // Get the full path from data-path attribute
             const isFolder = row.classList.contains('folder-row'); // Check if it's a folder
 
-            if (isFolder) {
-                // If it's a folder, send 'openFolder' command
-                vscode.postMessage({
-                    command: 'openFolder',
-                    path: path
-                });
-            } else {
-                // If it's a file, send 'openFile' command
-                vscode.postMessage({
-                    command: 'openFile',
-                    path: path
-                });
+            // Middle mouse button (button === 1)
+            if (e.button === 1) {
+                e.preventDefault(); // Prevent auto-scroll behavior
+                if (!isFolder) {
+                    // Open file in a new tab in the current editor group
+                    vscode.postMessage({
+                        command: 'openFileTab',
+                        path: path
+                    });
+                }
+                return;
+            }
+
+            // Left mouse button (button === 0) - existing behavior
+            if (e.button === 0) {
+                if (isFolder) {
+                    vscode.postMessage({
+                        command: 'openFolder',
+                        path: path
+                    });
+                } else {
+                    vscode.postMessage({
+                        command: 'openFile',
+                        path: path
+                    });
+                }
             }
         });
     });


### PR DESCRIPTION
- Add the ability to show/hide the Size, Date Created, and Date Modified columns in the file explorer view. Each column can be toggled from the view/title dropdown menu.

- Add date format selector with Full, Compact, and Relative display options

- Add resizable columns with drag handles and persistent widths

- Add middle-click to open file as permanent tab in current editor group (VScode EXPLORER behavior)